### PR TITLE
Fix reloading the loader

### DIFF
--- a/android/apps/rwt/app/src/main/java/com/realwear/acs/util/LoadingWebAppInterface.kt
+++ b/android/apps/rwt/app/src/main/java/com/realwear/acs/util/LoadingWebAppInterface.kt
@@ -24,6 +24,9 @@ import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import androidx.activity.ComponentActivity
 import com.realwear.acs.BuildConfig
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 class LoadingWebAppInterface(
@@ -77,6 +80,16 @@ class LoadingWebAppInterface(
         validateOrigin()
 
         return WEB_VIEW_SIZE
+    }
+
+    @JavascriptInterface
+    @Suppress("unused")
+    fun restartActivity() {
+        validateOrigin()
+
+        CoroutineScope(Dispatchers.Main).launch {
+            activity.recreate()
+        }
     }
 
     private fun validateOrigin() {

--- a/apps/loader/src/app/loader.component.ts
+++ b/apps/loader/src/app/loader.component.ts
@@ -158,7 +158,7 @@ export class LoaderComponent implements OnInit, OnDestroy {
   }
 
   tryAgain() {
-    this.connectivityService.restartAcivity();
+    this.connectivityService.restartActivity();
     this.isError$.next(false);
   }
 

--- a/apps/loader/src/app/loader.component.ts
+++ b/apps/loader/src/app/loader.component.ts
@@ -158,9 +158,7 @@ export class LoaderComponent implements OnInit, OnDestroy {
   }
 
   tryAgain() {
-    // Reload window
-    window.location.reload();
-
+    this.connectivityService.restartAcivity();
     this.isError$.next(false);
   }
 

--- a/libs/connectivity/src/lib/connectivity.service.ts
+++ b/libs/connectivity/src/lib/connectivity.service.ts
@@ -108,7 +108,7 @@ export class ConnectivityService implements OnDestroy {
     return LoadingAndroidInterface.downloadProgress();
   }
 
-  restartAcivity() {
+  restartActivity() {
     if (typeof LoadingAndroidInterface === 'undefined' || LoadingAndroidInterface === null) {
       console.error('LoadingAndroidInterface is not defined');
       return true;

--- a/libs/connectivity/src/lib/connectivity.service.ts
+++ b/libs/connectivity/src/lib/connectivity.service.ts
@@ -27,6 +27,7 @@ declare let LoadingAndroidInterface: {
   updateWebView: () => void;
   webViewSize: () => number;
   downloadProgress: () => number;
+  restartActivity: () => void;
 };
 
 @Injectable({
@@ -105,6 +106,15 @@ export class ConnectivityService implements OnDestroy {
     }
 
     return LoadingAndroidInterface.downloadProgress();
+  }
+
+  restartAcivity() {
+    if (typeof LoadingAndroidInterface === 'undefined' || LoadingAndroidInterface === null) {
+      console.error('LoadingAndroidInterface is not defined');
+      return true;
+    }
+
+    return LoadingAndroidInterface.restartActivity();
   }
 
   openConfigurator() {


### PR DESCRIPTION
Fixed a routing issue when reloading the loader app after the connection fails. We now do a harder reload from the Android side to remove the burden from Angular routing