### PR TITLE
Update app name for Korean

### DIFF
--- a/android/apps/rwt/app/src/main/res/values-ko/strings.xml
+++ b/android/apps/rwt/app/src/main/res/values-ko/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="app_name">협력하다</string>
+</resources>


### PR DESCRIPTION
Updated the app name for Korean speakers as the Korean speech recognizer doesn't understand the English pronunciation of "Collaborate"